### PR TITLE
Only copy DLL if not already present.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,8 +73,9 @@ def create_exension():
                     if not os.path.exists(dllpath):
                         static = True
                         break
-                    shutil.copy(dllpath,
-                                os.path.join(os.path.dirname(os.path.abspath(__file__)), 'src', 'CaChannel'))
+                    dll_filepath = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'src', 'CaChannel', dll)
+                    if not os.path.exists(dll_filepath):
+                        shutil.copy(dllpath, dll_filepath)
             macros += [('_CRT_SECURE_NO_WARNINGS', 'None'), ('EPICS_CALL_DLL', '')]
             cflags += ['/Z7']
             CMPL = 'msvc'


### PR DESCRIPTION
This fixes pip installs under windows 10 and python 3.8.

We were seeing an issue during `pip install cachannel` under windows 10 and python 3.8 where the copy appeared to be happening twice, and the second time it would get a permission denied error as the DLL was already present. This patch allows us to pip install correctly.