### PR TITLE
Use collections.abc.Sequence if possible

### DIFF
--- a/src/CaChannel/util.py
+++ b/src/CaChannel/util.py
@@ -37,7 +37,11 @@ _channels_ = {}
 
 
 def _ints_to_string(integers):
-    if isinstance(integers, collections.Sequence):
+    try:
+        sequence_type = collections.abc.Sequence # Python 3.10+
+    except AttributeError:
+        sequence_type = collections.Sequence
+    if isinstance(integers, sequence_type):
         stripped = itertools.takewhile(lambda x: x != 0, integers)
         if sys.hexversion < 0x03000000:
             value = ''.join([chr(c) for c in stripped])


### PR DESCRIPTION
`collections.Sequence` is no longer present in python 3.10, this changes `util.py` to checks whether `collections.abc.Sequence` is present and uses it if it is, defaulting back to `collections.Sequence` on older versions.