### PR TITLE
bug fixing stack smashing when using ca_sg_xxx

### DIFF
--- a/src/CaChannel/_ca.cpp
+++ b/src/CaChannel/_ca.cpp
@@ -1682,13 +1682,13 @@ static PyObject *Py_ca_sg_create(PyObject *self, PyObject *args)
     status = ca_sg_create(&gid);
     Py_END_ALLOW_THREADS
 
-    return Py_BuildValue("(Nl)", IntToIntEnum("ECA", status), gid);
+    return Py_BuildValue("(NI)", IntToIntEnum("ECA", status), gid);
 }
 
 static PyObject *Py_ca_sg_delete(PyObject *self, PyObject *args)
 {
     CA_SYNC_GID gid;
-    if(!PyArg_ParseTuple(args, "l", &gid))
+    if(!PyArg_ParseTuple(args, "I", &gid))
         return NULL;
 
     int status;
@@ -1711,7 +1711,7 @@ static PyObject *Py_ca_sg_get(PyObject *self, PyObject *args, PyObject *kws)
 
     const char *kwlist[] = {"gid", "chid", "chtype", "count", "use_numpy", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kws, "lO|OOb", (char **)kwlist, &gid, &pChid, &pType, &pCount, &use_numpy))
+    if (!PyArg_ParseTupleAndKeywords(args, kws, "IO|OOb", (char **)kwlist, &gid, &pChid, &pType, &pCount, &use_numpy))
         return NULL;
 
     chanId chid = (chanId) CAPSULE_EXTRACT(pChid, "chid");
@@ -1766,7 +1766,7 @@ static PyObject *Py_ca_sg_put(PyObject *self, PyObject *args, PyObject *kws)
 
     const char *kwlist[] = {"gid", "chid", "value", "chtype", "count", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kws, "lOO|OO", (char **)kwlist, &gid, &pChid, &pValue, &pType, &pCount))
+    if (!PyArg_ParseTupleAndKeywords(args, kws, "IOO|OO", (char **)kwlist, &gid, &pChid, &pValue, &pType, &pCount))
         return NULL;
 
     chanId chid = (chanId) CAPSULE_EXTRACT(pChid, "chid");
@@ -1795,7 +1795,7 @@ static PyObject *Py_ca_sg_reset(PyObject *self, PyObject *args)
     CA_SYNC_GID gid;
     int status;
 
-    if(!PyArg_ParseTuple(args, "l", &gid))
+    if(!PyArg_ParseTuple(args, "I", &gid))
         return NULL;
 
     Py_BEGIN_ALLOW_THREADS
@@ -1811,7 +1811,7 @@ static PyObject *Py_ca_sg_block(PyObject *self, PyObject *args)
     double timeout;
     int status;
 
-    if(!PyArg_ParseTuple(args, "ld", &gid, &timeout))
+    if(!PyArg_ParseTuple(args, "Id", &gid, &timeout))
         return NULL;
 
     Py_BEGIN_ALLOW_THREADS
@@ -1826,7 +1826,7 @@ static PyObject *Py_ca_sg_test(PyObject *self, PyObject *args)
     CA_SYNC_GID gid;
     int status;
 
-    if(!PyArg_ParseTuple(args, "l", &gid))
+    if(!PyArg_ParseTuple(args, "I", &gid))
         return NULL;
 
     Py_BEGIN_ALLOW_THREADS


### PR DESCRIPTION
CA_SYNC_GID is an integer not a long.

When I compiled the module locally I kept getting `*** stack smashing detected ***: terminated` whenever I would use `ca.sg_test()`. Later on I noticed that any `ca.sg_xxx()` that takes just the GID is susceptible to the same problem. After changing the format from `l` to `I` in the places the parse `CA_SYNC_GID gid` the problem was solved for me.

FWIW, my compiler lines were:
```
x86_64-linux-gnu-gcc -Wno-unused-result -Wsign-compare -g -Og -Wall -g -Og -fstack-protector-strong -Wformat -Werror=format-security -g -Og -fstack-protector-strong -Wformat -Werror=format-security -g -Og -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -I/data/data/Code/scanning/base-7.0.8/include -I/data/data/Code/scanning/base-7.0.8/include/os/Linux -I/data/data/Code/scanning/base-7.0.8/include/compiler/gcc -I/data/data/Code/scanning/dbg-venv/include -I/usr/include/python3.10d -c src/CaChannel/_ca.cpp -o build/temp.linux-x86_64-3.10-pydebug/src/CaChannel/_ca.o
x86_64-linux-gnu-g++ -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -g -Og -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 build/temp.linux-x86_64-3.10-pydebug/src/CaChannel/_ca.o /data/data/Code/scanning/base-7.0.8/lib/linux-x86_64/libca.a /data/data/Code/scanning/base-7.0.8/lib/linux-x86_64/libCom.a -L/data/data/Code/scanning/base-7.0.8/lib/linux-x86_64 -lrt -lreadline -o build/lib.linux-x86_64-3.10-pydebug/CaChannel/_ca.cpython-310d-x86_64-linux-gnu.so

```